### PR TITLE
Add Llama Stack Operator upstream to the operator

### DIFF
--- a/operators/templates/lls-operator-upstream.yaml
+++ b/operators/templates/lls-operator-upstream.yaml
@@ -1,0 +1,2544 @@
+---
+apiVersion: v1
+data:
+  controller_manager_config.yaml: |
+    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+    kind: ControllerManagerConfig
+    health:
+      healthProbeBindAddress: :8081
+    metrics:
+      bindAddress: 127.0.0.1:8080
+    webhook:
+      port: 9443
+    leaderElection:
+      leaderElect: true
+      resourceName: 54e06e98.llamastack.io
+    # leaderElectionReleaseOnCancel defines if the leader should step down volume
+    # when the Manager ends. This requires the binary to immediately end when the
+    # Manager is stopped, otherwise, this setting is unsafe. Setting this significantly
+    # speeds up voluntary leader transitions as the new leader don't have to wait
+    # LeaseDuration time first.
+    # In the default scaffold provided, the program ends immediately after
+    # the manager stops, so would be fine to enable this option. However,
+    # if you are doing or is intended to do any operation such as perform cleanups
+    # after the manager stops then its usage might be unsafe.
+    # leaderElectionReleaseOnCancel: true
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: llama-stack-k8s-operator
+  name: llama-stack-k8s-operator-manager-config
+  namespace: llama-stack-k8s-operator-system
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  labels:
+    app.kubernetes.io/name: llama-stack-k8s-operator
+  name: llamastackdistributions.llamastack.io
+spec:
+  group: llamastack.io
+  names:
+    kind: LlamaStackDistribution
+    listKind: LlamaStackDistributionList
+    plural: llamastackdistributions
+    shortNames:
+    - llsd
+    singular: llamastackdistribution
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.version.operatorVersion
+      name: Operator Version
+      type: string
+    - jsonPath: .status.version.llamaStackServerVersion
+      name: Server Version
+      type: string
+    - jsonPath: .status.availableReplicas
+      name: Available
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: LlamaStackDistributionSpec defines the desired state of LlamaStackDistribution.
+            properties:
+              replicas:
+                default: 1
+                format: int32
+                type: integer
+              server:
+                description: ServerSpec defines the desired state of llama server.
+                properties:
+                  containerSpec:
+                    description: ContainerSpec defines the llama-stack server container
+                      configuration.
+                    properties:
+                      args:
+                        items:
+                          type: string
+                        type: array
+                      command:
+                        items:
+                          type: string
+                        type: array
+                      env:
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      name:
+                        default: llama-stack
+                        type: string
+                      port:
+                        format: int32
+                        type: integer
+                      resources:
+                        description: ResourceRequirements describes the compute resource
+                          requirements.
+                        properties:
+                          claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+                              This field is immutable. It can only be set for containers.
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                        type: object
+                    type: object
+                  distribution:
+                    description: DistributionType defines the distribution configuration
+                      for llama-stack.
+                    properties:
+                      image:
+                        description: Image is the direct container image reference
+                          to use
+                        type: string
+                      name:
+                        description: Name is the distribution name that maps to supported
+                          distributions.
+                        type: string
+                    type: object
+                    x-kubernetes-validations:
+                    - message: Only one of name or image can be specified
+                      rule: '!(has(self.name) && has(self.image))'
+                  podOverrides:
+                    description: PodOverrides allows advanced pod-level customization.
+                    properties:
+                      serviceAccountName:
+                        description: |-
+                          ServiceAccountName allows users to specify their own ServiceAccount
+                          If not specified, the operator will use the default ServiceAccount
+                        type: string
+                      volumeMounts:
+                        items:
+                          description: VolumeMount describes a mounting of a Volume
+                            within a container.
+                          properties:
+                            mountPath:
+                              description: |-
+                                Path within the container at which the volume should be mounted.  Must
+                                not contain ':'.
+                              type: string
+                            mountPropagation:
+                              description: |-
+                                mountPropagation determines how mounts are propagated from the host
+                                to container and the other way around.
+                                When not set, MountPropagationNone is used.
+                                This field is beta in 1.10.
+                              type: string
+                            name:
+                              description: This must match the Name of a Volume.
+                              type: string
+                            readOnly:
+                              description: |-
+                                Mounted read-only if true, read-write otherwise (false or unspecified).
+                                Defaults to false.
+                              type: boolean
+                            subPath:
+                              description: |-
+                                Path within the volume from which the container's volume should be mounted.
+                                Defaults to "" (volume's root).
+                              type: string
+                            subPathExpr:
+                              description: |-
+                                Expanded path within the volume from which the container's volume should be mounted.
+                                Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                Defaults to "" (volume's root).
+                                SubPathExpr and SubPath are mutually exclusive.
+                              type: string
+                          required:
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
+                      volumes:
+                        items:
+                          description: Volume represents a named volume in a pod that
+                            may be accessed by any container in the pod.
+                          properties:
+                            awsElasticBlockStore:
+                              description: |-
+                                awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                                kubelet's host machine and then exposed to the pod.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                              properties:
+                                fsType:
+                                  description: |-
+                                    fsType is the filesystem type of the volume that you want to mount.
+                                    Tip: Ensure that the filesystem type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                  type: string
+                                partition:
+                                  description: |-
+                                    partition is the partition in the volume that you want to mount.
+                                    If omitted, the default is to mount by volume name.
+                                    Examples: For volume /dev/sda1, you specify the partition as "1".
+                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  description: |-
+                                    readOnly value true will force the readOnly setting in VolumeMounts.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                  type: boolean
+                                volumeID:
+                                  description: |-
+                                    volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                  type: string
+                              required:
+                              - volumeID
+                              type: object
+                            azureDisk:
+                              description: azureDisk represents an Azure Data Disk
+                                mount on the host and bind mount to the pod.
+                              properties:
+                                cachingMode:
+                                  description: 'cachingMode is the Host Caching mode:
+                                    None, Read Only, Read Write.'
+                                  type: string
+                                diskName:
+                                  description: diskName is the Name of the data disk
+                                    in the blob storage
+                                  type: string
+                                diskURI:
+                                  description: diskURI is the URI of data disk in
+                                    the blob storage
+                                  type: string
+                                fsType:
+                                  description: |-
+                                    fsType is Filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  type: string
+                                kind:
+                                  description: 'kind expected values are Shared: multiple
+                                    blob disks per storage account  Dedicated: single
+                                    blob disk per storage account  Managed: azure
+                                    managed data disk (only in managed availability
+                                    set). defaults to shared'
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
+                                  type: boolean
+                              required:
+                              - diskName
+                              - diskURI
+                              type: object
+                            azureFile:
+                              description: azureFile represents an Azure File Service
+                                mount on the host and bind mount to the pod.
+                              properties:
+                                readOnly:
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
+                                  type: boolean
+                                secretName:
+                                  description: secretName is the  name of secret that
+                                    contains Azure Storage Account Name and Key
+                                  type: string
+                                shareName:
+                                  description: shareName is the azure share Name
+                                  type: string
+                              required:
+                              - secretName
+                              - shareName
+                              type: object
+                            cephfs:
+                              description: cephFS represents a Ceph FS mount on the
+                                host that shares a pod's lifetime
+                              properties:
+                                monitors:
+                                  description: |-
+                                    monitors is Required: Monitors is a collection of Ceph monitors
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                  items:
+                                    type: string
+                                  type: array
+                                path:
+                                  description: 'path is Optional: Used as the mounted
+                                    root, rather than the full Ceph tree, default
+                                    is /'
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                  type: boolean
+                                secretFile:
+                                  description: |-
+                                    secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                  type: string
+                                secretRef:
+                                  description: |-
+                                    secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                user:
+                                  description: |-
+                                    user is optional: User is the rados user name, default is admin
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                  type: string
+                              required:
+                              - monitors
+                              type: object
+                            cinder:
+                              description: |-
+                                cinder represents a cinder volume attached and mounted on kubelets host machine.
+                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                              properties:
+                                fsType:
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                  type: boolean
+                                secretRef:
+                                  description: |-
+                                    secretRef is optional: points to a secret object containing parameters used to connect
+                                    to OpenStack.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                volumeID:
+                                  description: |-
+                                    volumeID used to identify the volume in cinder.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                  type: string
+                              required:
+                              - volumeID
+                              type: object
+                            configMap:
+                              description: configMap represents a configMap that should
+                                populate this volume
+                              properties:
+                                defaultMode:
+                                  description: |-
+                                    defaultMode is optional: mode bits used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                    Defaults to 0644.
+                                    Directories within the path are not affected by this setting.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
+                                  format: int32
+                                  type: integer
+                                items:
+                                  description: |-
+                                    items if unspecified, each key-value pair in the Data field of the referenced
+                                    ConfigMap will be projected into the volume as a file whose name is the
+                                    key and content is the value. If specified, the listed keys will be
+                                    projected into the specified paths, and unlisted keys will not be
+                                    present. If a key is specified which is not present in the ConfigMap,
+                                    the volume setup will error unless it is marked optional. Paths must be
+                                    relative and may not contain the '..' path or start with '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: key is the key to project.
+                                        type: string
+                                      mode:
+                                        description: |-
+                                          mode is Optional: mode bits used to set permissions on this file.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          If not specified, the volume defaultMode will be used.
+                                          This might be in conflict with other options that affect the file
+                                          mode, like fsGroup, and the result can be other mode bits set.
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: |-
+                                          path is the relative path of the file to map the key to.
+                                          May not be an absolute path.
+                                          May not contain the path element '..'.
+                                          May not start with the string '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                name:
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: optional specify whether the ConfigMap
+                                    or its keys must be defined
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            csi:
+                              description: csi (Container Storage Interface) represents
+                                ephemeral storage that is handled by certain external
+                                CSI drivers (Beta feature).
+                              properties:
+                                driver:
+                                  description: |-
+                                    driver is the name of the CSI driver that handles this volume.
+                                    Consult with your admin for the correct name as registered in the cluster.
+                                  type: string
+                                fsType:
+                                  description: |-
+                                    fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                    If not provided, the empty value is passed to the associated CSI driver
+                                    which will determine the default filesystem to apply.
+                                  type: string
+                                nodePublishSecretRef:
+                                  description: |-
+                                    nodePublishSecretRef is a reference to the secret object containing
+                                    sensitive information to pass to the CSI driver to complete the CSI
+                                    NodePublishVolume and NodeUnpublishVolume calls.
+                                    This field is optional, and  may be empty if no secret is required. If the
+                                    secret object contains more than one secret, all secret references are passed.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                readOnly:
+                                  description: |-
+                                    readOnly specifies a read-only configuration for the volume.
+                                    Defaults to false (read/write).
+                                  type: boolean
+                                volumeAttributes:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    volumeAttributes stores driver-specific properties that are passed to the CSI
+                                    driver. Consult your driver's documentation for supported values.
+                                  type: object
+                              required:
+                              - driver
+                              type: object
+                            downwardAPI:
+                              description: downwardAPI represents downward API about
+                                the pod that should populate this volume
+                              properties:
+                                defaultMode:
+                                  description: |-
+                                    Optional: mode bits to use on created files by default. Must be a
+                                    Optional: mode bits used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                    Defaults to 0644.
+                                    Directories within the path are not affected by this setting.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
+                                  format: int32
+                                  type: integer
+                                items:
+                                  description: Items is a list of downward API volume
+                                    file
+                                  items:
+                                    description: DownwardAPIVolumeFile represents
+                                      information to create the file containing the
+                                      pod field
+                                    properties:
+                                      fieldRef:
+                                        description: 'Required: Selects a field of
+                                          the pod: only annotations, labels, name
+                                          and namespace are supported.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      mode:
+                                        description: |-
+                                          Optional: mode bits used to set permissions on this file, must be an octal value
+                                          between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          If not specified, the volume defaultMode will be used.
+                                          This might be in conflict with other options that affect the file
+                                          mode, like fsGroup, and the result can be other mode bits set.
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: 'Required: Path is  the relative
+                                          path name of the file to be created. Must
+                                          not be absolute or contain the ''..'' path.
+                                          Must be utf-8 encoded. The first item of
+                                          the relative path must not start with ''..'''
+                                        type: string
+                                      resourceFieldRef:
+                                        description: |-
+                                          Selects a resource of the container: only resources limits and requests
+                                          (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    required:
+                                    - path
+                                    type: object
+                                  type: array
+                              type: object
+                            emptyDir:
+                              description: |-
+                                emptyDir represents a temporary directory that shares a pod's lifetime.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                              properties:
+                                medium:
+                                  description: |-
+                                    medium represents what type of storage medium should back this directory.
+                                    The default is "" which means to use the node's default medium.
+                                    Must be an empty string (default) or Memory.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                  type: string
+                                sizeLimit:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                                    The size limit is also applicable for memory medium.
+                                    The maximum usage on memory medium EmptyDir would be the minimum value between
+                                    the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                                    The default is nil which means that the limit is undefined.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            ephemeral:
+                              description: |-
+                                ephemeral represents a volume that is handled by a cluster storage driver.
+                                The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
+                                and deleted when the pod is removed.
+
+                                Use this if:
+                                a) the volume is only needed while the pod runs,
+                                b) features of normal volumes like restoring from snapshot or capacity
+                                   tracking are needed,
+                                c) the storage driver is specified through a storage class, and
+                                d) the storage driver supports dynamic volume provisioning through
+                                   a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                   information on the connection between this volume type
+                                   and PersistentVolumeClaim).
+
+                                Use PersistentVolumeClaim or one of the vendor-specific
+                                APIs for volumes that persist for longer than the lifecycle
+                                of an individual pod.
+
+                                Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
+                                be used that way - see the documentation of the driver for
+                                more information.
+
+                                A pod can use both types of ephemeral volumes and
+                                persistent volumes at the same time.
+                              properties:
+                                volumeClaimTemplate:
+                                  description: |-
+                                    Will be used to create a stand-alone PVC to provision the volume.
+                                    The pod in which this EphemeralVolumeSource is embedded will be the
+                                    owner of the PVC, i.e. the PVC will be deleted together with the
+                                    pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                                    `<volume name>` is the name from the `PodSpec.Volumes` array
+                                    entry. Pod validation will reject the pod if the concatenated name
+                                    is not valid for a PVC (for example, too long).
+
+                                    An existing PVC with that name that is not owned by the pod
+                                    will *not* be used for the pod to avoid using an unrelated
+                                    volume by mistake. Starting the pod is then blocked until
+                                    the unrelated PVC is removed. If such a pre-created PVC is
+                                    meant to be used by the pod, the PVC has to updated with an
+                                    owner reference to the pod once the pod exists. Normally
+                                    this should not be necessary, but it may be useful when
+                                    manually reconstructing a broken cluster.
+
+                                    This field is read-only and no changes will be made by Kubernetes
+                                    to the PVC after it has been created.
+
+                                    Required, must not be nil.
+                                  properties:
+                                    metadata:
+                                      description: |-
+                                        May contain labels and annotations that will be copied into the PVC
+                                        when creating it. No other fields are allowed and will be rejected during
+                                        validation.
+                                      type: object
+                                    spec:
+                                      description: |-
+                                        The specification for the PersistentVolumeClaim. The entire content is
+                                        copied unchanged into the PVC that gets created from this
+                                        template. The same fields as in a PersistentVolumeClaim
+                                        are also valid here.
+                                      properties:
+                                        accessModes:
+                                          description: |-
+                                            accessModes contains the desired access modes the volume should have.
+                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                                          items:
+                                            type: string
+                                          type: array
+                                        dataSource:
+                                          description: |-
+                                            dataSource field can be used to specify either:
+                                            * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                            * An existing PVC (PersistentVolumeClaim)
+                                            If the provisioner or an external controller can support the specified data source,
+                                            it will create a new volume based on the contents of the specified data source.
+                                            When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                            and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                            If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                                          properties:
+                                            apiGroup:
+                                              description: |-
+                                                APIGroup is the group for the resource being referenced.
+                                                If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                For any other third-party types, APIGroup is required.
+                                              type: string
+                                            kind:
+                                              description: Kind is the type of resource
+                                                being referenced
+                                              type: string
+                                            name:
+                                              description: Name is the name of resource
+                                                being referenced
+                                              type: string
+                                          required:
+                                          - kind
+                                          - name
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        dataSourceRef:
+                                          description: |-
+                                            dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                            volume is desired. This may be any object from a non-empty API group (non
+                                            core object) or a PersistentVolumeClaim object.
+                                            When this field is specified, volume binding will only succeed if the type of
+                                            the specified object matches some installed volume populator or dynamic
+                                            provisioner.
+                                            This field will replace the functionality of the dataSource field and as such
+                                            if both fields are non-empty, they must have the same value. For backwards
+                                            compatibility, when namespace isn't specified in dataSourceRef,
+                                            both fields (dataSource and dataSourceRef) will be set to the same
+                                            value automatically if one of them is empty and the other is non-empty.
+                                            When namespace is specified in dataSourceRef,
+                                            dataSource isn't set to the same value and must be empty.
+                                            There are three important differences between dataSource and dataSourceRef:
+                                            * While dataSource only allows two specific types of objects, dataSourceRef
+                                              allows any non-core object, as well as PersistentVolumeClaim objects.
+                                            * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                              preserves all values, and generates an error if a disallowed value is
+                                              specified.
+                                            * While dataSource only allows local objects, dataSourceRef allows objects
+                                              in any namespaces.
+                                            (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                            (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                          properties:
+                                            apiGroup:
+                                              description: |-
+                                                APIGroup is the group for the resource being referenced.
+                                                If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                For any other third-party types, APIGroup is required.
+                                              type: string
+                                            kind:
+                                              description: Kind is the type of resource
+                                                being referenced
+                                              type: string
+                                            name:
+                                              description: Name is the name of resource
+                                                being referenced
+                                              type: string
+                                            namespace:
+                                              description: |-
+                                                Namespace is the namespace of resource being referenced
+                                                Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                                (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                              type: string
+                                          required:
+                                          - kind
+                                          - name
+                                          type: object
+                                        resources:
+                                          description: |-
+                                            resources represents the minimum resources the volume should have.
+                                            If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                            that are lower than previous value but must still be higher than capacity recorded in the
+                                            status field of the claim.
+                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                                          properties:
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              description: |-
+                                                Limits describes the maximum amount of compute resources allowed.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              description: |-
+                                                Requests describes the minimum amount of compute resources required.
+                                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                              type: object
+                                          type: object
+                                        selector:
+                                          description: selector is a label query over
+                                            volumes to consider for binding.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        storageClassName:
+                                          description: |-
+                                            storageClassName is the name of the StorageClass required by the claim.
+                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                                          type: string
+                                        volumeAttributesClassName:
+                                          description: |-
+                                            volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                            If specified, the CSI driver will create or update the volume with the attributes defined
+                                            in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                            it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                                            will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                                            If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                                            will be set by the persistentvolume controller if it exists.
+                                            If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                            set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                            exists.
+                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
+                                            (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
+                                          type: string
+                                        volumeMode:
+                                          description: |-
+                                            volumeMode defines what type of volume is required by the claim.
+                                            Value of Filesystem is implied when not included in claim spec.
+                                          type: string
+                                        volumeName:
+                                          description: volumeName is the binding reference
+                                            to the PersistentVolume backing this claim.
+                                          type: string
+                                      type: object
+                                  required:
+                                  - spec
+                                  type: object
+                              type: object
+                            fc:
+                              description: fc represents a Fibre Channel resource
+                                that is attached to a kubelet's host machine and then
+                                exposed to the pod.
+                              properties:
+                                fsType:
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  type: string
+                                lun:
+                                  description: 'lun is Optional: FC target lun number'
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  description: |-
+                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
+                                  type: boolean
+                                targetWWNs:
+                                  description: 'targetWWNs is Optional: FC target
+                                    worldwide names (WWNs)'
+                                  items:
+                                    type: string
+                                  type: array
+                                wwids:
+                                  description: |-
+                                    wwids Optional: FC volume world wide identifiers (wwids)
+                                    Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            flexVolume:
+                              description: |-
+                                flexVolume represents a generic volume resource that is
+                                provisioned/attached using an exec based plugin.
+                              properties:
+                                driver:
+                                  description: driver is the name of the driver to
+                                    use for this volume.
+                                  type: string
+                                fsType:
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                                  type: string
+                                options:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'options is Optional: this field holds
+                                    extra command options if any.'
+                                  type: object
+                                readOnly:
+                                  description: |-
+                                    readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
+                                  type: boolean
+                                secretRef:
+                                  description: |-
+                                    secretRef is Optional: secretRef is reference to the secret object containing
+                                    sensitive information to pass to the plugin scripts. This may be
+                                    empty if no secret object is specified. If the secret object
+                                    contains more than one secret, all secrets are passed to the plugin
+                                    scripts.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - driver
+                              type: object
+                            flocker:
+                              description: flocker represents a Flocker volume attached
+                                to a kubelet's host machine. This depends on the Flocker
+                                control service being running
+                              properties:
+                                datasetName:
+                                  description: |-
+                                    datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                    should be considered as deprecated
+                                  type: string
+                                datasetUUID:
+                                  description: datasetUUID is the UUID of the dataset.
+                                    This is unique identifier of a Flocker dataset
+                                  type: string
+                              type: object
+                            gcePersistentDisk:
+                              description: |-
+                                gcePersistentDisk represents a GCE Disk resource that is attached to a
+                                kubelet's host machine and then exposed to the pod.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                              properties:
+                                fsType:
+                                  description: |-
+                                    fsType is filesystem type of the volume that you want to mount.
+                                    Tip: Ensure that the filesystem type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                  type: string
+                                partition:
+                                  description: |-
+                                    partition is the partition in the volume that you want to mount.
+                                    If omitted, the default is to mount by volume name.
+                                    Examples: For volume /dev/sda1, you specify the partition as "1".
+                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                  format: int32
+                                  type: integer
+                                pdName:
+                                  description: |-
+                                    pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly here will force the ReadOnly setting in VolumeMounts.
+                                    Defaults to false.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                  type: boolean
+                              required:
+                              - pdName
+                              type: object
+                            gitRepo:
+                              description: |-
+                                gitRepo represents a git repository at a particular revision.
+                                DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                                EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                                into the Pod's container.
+                              properties:
+                                directory:
+                                  description: |-
+                                    directory is the target directory name.
+                                    Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                                    git repository.  Otherwise, if specified, the volume will contain the git repository in
+                                    the subdirectory with the given name.
+                                  type: string
+                                repository:
+                                  description: repository is the URL
+                                  type: string
+                                revision:
+                                  description: revision is the commit hash for the
+                                    specified revision.
+                                  type: string
+                              required:
+                              - repository
+                              type: object
+                            glusterfs:
+                              description: |-
+                                glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                                More info: https://examples.k8s.io/volumes/glusterfs/README.md
+                              properties:
+                                endpoints:
+                                  description: |-
+                                    endpoints is the endpoint name that details Glusterfs topology.
+                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                  type: string
+                                path:
+                                  description: |-
+                                    path is the Glusterfs volume path.
+                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                    Defaults to false.
+                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                  type: boolean
+                              required:
+                              - endpoints
+                              - path
+                              type: object
+                            hostPath:
+                              description: |-
+                                hostPath represents a pre-existing file or directory on the host
+                                machine that is directly exposed to the container. This is generally
+                                used for system agents or other privileged things that are allowed
+                                to see the host machine. Most containers will NOT need this.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                              properties:
+                                path:
+                                  description: |-
+                                    path of the directory on the host.
+                                    If the path is a symlink, it will follow the link to the real path.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                  type: string
+                                type:
+                                  description: |-
+                                    type for HostPath Volume
+                                    Defaults to ""
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            iscsi:
+                              description: |-
+                                iscsi represents an ISCSI Disk resource that is attached to a
+                                kubelet's host machine and then exposed to the pod.
+                                More info: https://examples.k8s.io/volumes/iscsi/README.md
+                              properties:
+                                chapAuthDiscovery:
+                                  description: chapAuthDiscovery defines whether support
+                                    iSCSI Discovery CHAP authentication
+                                  type: boolean
+                                chapAuthSession:
+                                  description: chapAuthSession defines whether support
+                                    iSCSI Session CHAP authentication
+                                  type: boolean
+                                fsType:
+                                  description: |-
+                                    fsType is the filesystem type of the volume that you want to mount.
+                                    Tip: Ensure that the filesystem type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                  type: string
+                                initiatorName:
+                                  description: |-
+                                    initiatorName is the custom iSCSI Initiator Name.
+                                    If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                                    <target portal>:<volume name> will be created for the connection.
+                                  type: string
+                                iqn:
+                                  description: iqn is the target iSCSI Qualified Name.
+                                  type: string
+                                iscsiInterface:
+                                  description: |-
+                                    iscsiInterface is the interface Name that uses an iSCSI transport.
+                                    Defaults to 'default' (tcp).
+                                  type: string
+                                lun:
+                                  description: lun represents iSCSI Target Lun number.
+                                  format: int32
+                                  type: integer
+                                portals:
+                                  description: |-
+                                    portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                                    is other than default (typically TCP ports 860 and 3260).
+                                  items:
+                                    type: string
+                                  type: array
+                                readOnly:
+                                  description: |-
+                                    readOnly here will force the ReadOnly setting in VolumeMounts.
+                                    Defaults to false.
+                                  type: boolean
+                                secretRef:
+                                  description: secretRef is the CHAP Secret for iSCSI
+                                    target and initiator authentication
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                targetPortal:
+                                  description: |-
+                                    targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                                    is other than default (typically TCP ports 860 and 3260).
+                                  type: string
+                              required:
+                              - iqn
+                              - lun
+                              - targetPortal
+                              type: object
+                            name:
+                              description: |-
+                                name of the volume.
+                                Must be a DNS_LABEL and unique within the pod.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            nfs:
+                              description: |-
+                                nfs represents an NFS mount on the host that shares a pod's lifetime
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                              properties:
+                                path:
+                                  description: |-
+                                    path that is exported by the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly here will force the NFS export to be mounted with read-only permissions.
+                                    Defaults to false.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: boolean
+                                server:
+                                  description: |-
+                                    server is the hostname or IP address of the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: string
+                              required:
+                              - path
+                              - server
+                              type: object
+                            persistentVolumeClaim:
+                              description: |-
+                                persistentVolumeClaimVolumeSource represents a reference to a
+                                PersistentVolumeClaim in the same namespace.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                              properties:
+                                claimName:
+                                  description: |-
+                                    claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly Will force the ReadOnly setting in VolumeMounts.
+                                    Default false.
+                                  type: boolean
+                              required:
+                              - claimName
+                              type: object
+                            photonPersistentDisk:
+                              description: photonPersistentDisk represents a PhotonController
+                                persistent disk attached and mounted on kubelets host
+                                machine
+                              properties:
+                                fsType:
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  type: string
+                                pdID:
+                                  description: pdID is the ID that identifies Photon
+                                    Controller persistent disk
+                                  type: string
+                              required:
+                              - pdID
+                              type: object
+                            portworxVolume:
+                              description: portworxVolume represents a portworx volume
+                                attached and mounted on kubelets host machine
+                              properties:
+                                fsType:
+                                  description: |-
+                                    fSType represents the filesystem type to mount
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
+                                  type: boolean
+                                volumeID:
+                                  description: volumeID uniquely identifies a Portworx
+                                    volume
+                                  type: string
+                              required:
+                              - volumeID
+                              type: object
+                            projected:
+                              description: projected items for all in one resources
+                                secrets, configmaps, and downward API
+                              properties:
+                                defaultMode:
+                                  description: |-
+                                    defaultMode are the mode bits used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                    Directories within the path are not affected by this setting.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
+                                  format: int32
+                                  type: integer
+                                sources:
+                                  description: sources is the list of volume projections
+                                  items:
+                                    description: Projection that may be projected
+                                      along with other supported volume types
+                                    properties:
+                                      clusterTrustBundle:
+                                        description: |-
+                                          ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
+                                          of ClusterTrustBundle objects in an auto-updating file.
+
+                                          Alpha, gated by the ClusterTrustBundleProjection feature gate.
+
+                                          ClusterTrustBundle objects can either be selected by name, or by the
+                                          combination of signer name and a label selector.
+
+                                          Kubelet performs aggressive normalization of the PEM contents written
+                                          into the pod filesystem.  Esoteric PEM features such as inter-block
+                                          comments and block headers are stripped.  Certificates are deduplicated.
+                                          The ordering of certificates within the file is arbitrary, and Kubelet
+                                          may change the order over time.
+                                        properties:
+                                          labelSelector:
+                                            description: |-
+                                              Select all ClusterTrustBundles that match this label selector.  Only has
+                                              effect if signerName is set.  Mutually-exclusive with name.  If unset,
+                                              interpreted as "match nothing".  If set but empty, interpreted as "match
+                                              everything".
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          name:
+                                            description: |-
+                                              Select a single ClusterTrustBundle by object name.  Mutually-exclusive
+                                              with signerName and labelSelector.
+                                            type: string
+                                          optional:
+                                            description: |-
+                                              If true, don't block pod startup if the referenced ClusterTrustBundle(s)
+                                              aren't available.  If using name, then the named ClusterTrustBundle is
+                                              allowed not to exist.  If using signerName, then the combination of
+                                              signerName and labelSelector is allowed to match zero
+                                              ClusterTrustBundles.
+                                            type: boolean
+                                          path:
+                                            description: Relative path from the volume
+                                              root to write the bundle.
+                                            type: string
+                                          signerName:
+                                            description: |-
+                                              Select all ClusterTrustBundles that match this signer name.
+                                              Mutually-exclusive with name.  The contents of all selected
+                                              ClusterTrustBundles will be unified and deduplicated.
+                                            type: string
+                                        required:
+                                        - path
+                                        type: object
+                                      configMap:
+                                        description: configMap information about the
+                                          configMap data to project
+                                        properties:
+                                          items:
+                                            description: |-
+                                              items if unspecified, each key-value pair in the Data field of the referenced
+                                              ConfigMap will be projected into the volume as a file whose name is the
+                                              key and content is the value. If specified, the listed keys will be
+                                              projected into the specified paths, and unlisted keys will not be
+                                              present. If a key is specified which is not present in the ConfigMap,
+                                              the volume setup will error unless it is marked optional. Paths must be
+                                              relative and may not contain the '..' path or start with '..'.
+                                            items:
+                                              description: Maps a string key to a
+                                                path within a volume.
+                                              properties:
+                                                key:
+                                                  description: key is the key to project.
+                                                  type: string
+                                                mode:
+                                                  description: |-
+                                                    mode is Optional: mode bits used to set permissions on this file.
+                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                    If not specified, the volume defaultMode will be used.
+                                                    This might be in conflict with other options that affect the file
+                                                    mode, like fsGroup, and the result can be other mode bits set.
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: |-
+                                                    path is the relative path of the file to map the key to.
+                                                    May not be an absolute path.
+                                                    May not contain the path element '..'.
+                                                    May not start with the string '..'.
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              type: object
+                                            type: array
+                                          name:
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: optional specify whether
+                                              the ConfigMap or its keys must be defined
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      downwardAPI:
+                                        description: downwardAPI information about
+                                          the downwardAPI data to project
+                                        properties:
+                                          items:
+                                            description: Items is a list of DownwardAPIVolume
+                                              file
+                                            items:
+                                              description: DownwardAPIVolumeFile represents
+                                                information to create the file containing
+                                                the pod field
+                                              properties:
+                                                fieldRef:
+                                                  description: 'Required: Selects
+                                                    a field of the pod: only annotations,
+                                                    labels, name and namespace are
+                                                    supported.'
+                                                  properties:
+                                                    apiVersion:
+                                                      description: Version of the
+                                                        schema the FieldPath is written
+                                                        in terms of, defaults to "v1".
+                                                      type: string
+                                                    fieldPath:
+                                                      description: Path of the field
+                                                        to select in the specified
+                                                        API version.
+                                                      type: string
+                                                  required:
+                                                  - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                mode:
+                                                  description: |-
+                                                    Optional: mode bits used to set permissions on this file, must be an octal value
+                                                    between 0000 and 0777 or a decimal value between 0 and 511.
+                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                    If not specified, the volume defaultMode will be used.
+                                                    This might be in conflict with other options that affect the file
+                                                    mode, like fsGroup, and the result can be other mode bits set.
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: 'Required: Path is  the
+                                                    relative path name of the file
+                                                    to be created. Must not be absolute
+                                                    or contain the ''..'' path. Must
+                                                    be utf-8 encoded. The first item
+                                                    of the relative path must not
+                                                    start with ''..'''
+                                                  type: string
+                                                resourceFieldRef:
+                                                  description: |-
+                                                    Selects a resource of the container: only resources limits and requests
+                                                    (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                                  properties:
+                                                    containerName:
+                                                      description: 'Container name:
+                                                        required for volumes, optional
+                                                        for env vars'
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      description: Specifies the output
+                                                        format of the exposed resources,
+                                                        defaults to "1"
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      description: 'Required: resource
+                                                        to select'
+                                                      type: string
+                                                  required:
+                                                  - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              required:
+                                              - path
+                                              type: object
+                                            type: array
+                                        type: object
+                                      secret:
+                                        description: secret information about the
+                                          secret data to project
+                                        properties:
+                                          items:
+                                            description: |-
+                                              items if unspecified, each key-value pair in the Data field of the referenced
+                                              Secret will be projected into the volume as a file whose name is the
+                                              key and content is the value. If specified, the listed keys will be
+                                              projected into the specified paths, and unlisted keys will not be
+                                              present. If a key is specified which is not present in the Secret,
+                                              the volume setup will error unless it is marked optional. Paths must be
+                                              relative and may not contain the '..' path or start with '..'.
+                                            items:
+                                              description: Maps a string key to a
+                                                path within a volume.
+                                              properties:
+                                                key:
+                                                  description: key is the key to project.
+                                                  type: string
+                                                mode:
+                                                  description: |-
+                                                    mode is Optional: mode bits used to set permissions on this file.
+                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                    If not specified, the volume defaultMode will be used.
+                                                    This might be in conflict with other options that affect the file
+                                                    mode, like fsGroup, and the result can be other mode bits set.
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: |-
+                                                    path is the relative path of the file to map the key to.
+                                                    May not be an absolute path.
+                                                    May not contain the path element '..'.
+                                                    May not start with the string '..'.
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              type: object
+                                            type: array
+                                          name:
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: optional field specify whether
+                                              the Secret or its key must be defined
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      serviceAccountToken:
+                                        description: serviceAccountToken is information
+                                          about the serviceAccountToken data to project
+                                        properties:
+                                          audience:
+                                            description: |-
+                                              audience is the intended audience of the token. A recipient of a token
+                                              must identify itself with an identifier specified in the audience of the
+                                              token, and otherwise should reject the token. The audience defaults to the
+                                              identifier of the apiserver.
+                                            type: string
+                                          expirationSeconds:
+                                            description: |-
+                                              expirationSeconds is the requested duration of validity of the service
+                                              account token. As the token approaches expiration, the kubelet volume
+                                              plugin will proactively rotate the service account token. The kubelet will
+                                              start trying to rotate the token if the token is older than 80 percent of
+                                              its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                              and must be at least 10 minutes.
+                                            format: int64
+                                            type: integer
+                                          path:
+                                            description: |-
+                                              path is the path relative to the mount point of the file to project the
+                                              token into.
+                                            type: string
+                                        required:
+                                        - path
+                                        type: object
+                                    type: object
+                                  type: array
+                              type: object
+                            quobyte:
+                              description: quobyte represents a Quobyte mount on the
+                                host that shares a pod's lifetime
+                              properties:
+                                group:
+                                  description: |-
+                                    group to map volume access to
+                                    Default is no group
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                                    Defaults to false.
+                                  type: boolean
+                                registry:
+                                  description: |-
+                                    registry represents a single or multiple Quobyte Registry services
+                                    specified as a string as host:port pair (multiple entries are separated with commas)
+                                    which acts as the central registry for volumes
+                                  type: string
+                                tenant:
+                                  description: |-
+                                    tenant owning the given Quobyte volume in the Backend
+                                    Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                                  type: string
+                                user:
+                                  description: |-
+                                    user to map volume access to
+                                    Defaults to serivceaccount user
+                                  type: string
+                                volume:
+                                  description: volume is a string that references
+                                    an already created Quobyte volume by name.
+                                  type: string
+                              required:
+                              - registry
+                              - volume
+                              type: object
+                            rbd:
+                              description: |-
+                                rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md
+                              properties:
+                                fsType:
+                                  description: |-
+                                    fsType is the filesystem type of the volume that you want to mount.
+                                    Tip: Ensure that the filesystem type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                  type: string
+                                image:
+                                  description: |-
+                                    image is the rados image name.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                  type: string
+                                keyring:
+                                  description: |-
+                                    keyring is the path to key ring for RBDUser.
+                                    Default is /etc/ceph/keyring.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                  type: string
+                                monitors:
+                                  description: |-
+                                    monitors is a collection of Ceph monitors.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                  items:
+                                    type: string
+                                  type: array
+                                pool:
+                                  description: |-
+                                    pool is the rados pool name.
+                                    Default is rbd.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly here will force the ReadOnly setting in VolumeMounts.
+                                    Defaults to false.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                  type: boolean
+                                secretRef:
+                                  description: |-
+                                    secretRef is name of the authentication secret for RBDUser. If provided
+                                    overrides keyring.
+                                    Default is nil.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                user:
+                                  description: |-
+                                    user is the rados user name.
+                                    Default is admin.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                  type: string
+                              required:
+                              - image
+                              - monitors
+                              type: object
+                            scaleIO:
+                              description: scaleIO represents a ScaleIO persistent
+                                volume attached and mounted on Kubernetes nodes.
+                              properties:
+                                fsType:
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs".
+                                    Default is "xfs".
+                                  type: string
+                                gateway:
+                                  description: gateway is the host address of the
+                                    ScaleIO API Gateway.
+                                  type: string
+                                protectionDomain:
+                                  description: protectionDomain is the name of the
+                                    ScaleIO Protection Domain for the configured storage.
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
+                                  type: boolean
+                                secretRef:
+                                  description: |-
+                                    secretRef references to the secret for ScaleIO user and other
+                                    sensitive information. If this is not provided, Login operation will fail.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                sslEnabled:
+                                  description: sslEnabled Flag enable/disable SSL
+                                    communication with Gateway, default false
+                                  type: boolean
+                                storageMode:
+                                  description: |-
+                                    storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+                                    Default is ThinProvisioned.
+                                  type: string
+                                storagePool:
+                                  description: storagePool is the ScaleIO Storage
+                                    Pool associated with the protection domain.
+                                  type: string
+                                system:
+                                  description: system is the name of the storage system
+                                    as configured in ScaleIO.
+                                  type: string
+                                volumeName:
+                                  description: |-
+                                    volumeName is the name of a volume already created in the ScaleIO system
+                                    that is associated with this volume source.
+                                  type: string
+                              required:
+                              - gateway
+                              - secretRef
+                              - system
+                              type: object
+                            secret:
+                              description: |-
+                                secret represents a secret that should populate this volume.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                              properties:
+                                defaultMode:
+                                  description: |-
+                                    defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values
+                                    for mode bits. Defaults to 0644.
+                                    Directories within the path are not affected by this setting.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
+                                  format: int32
+                                  type: integer
+                                items:
+                                  description: |-
+                                    items If unspecified, each key-value pair in the Data field of the referenced
+                                    Secret will be projected into the volume as a file whose name is the
+                                    key and content is the value. If specified, the listed keys will be
+                                    projected into the specified paths, and unlisted keys will not be
+                                    present. If a key is specified which is not present in the Secret,
+                                    the volume setup will error unless it is marked optional. Paths must be
+                                    relative and may not contain the '..' path or start with '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: key is the key to project.
+                                        type: string
+                                      mode:
+                                        description: |-
+                                          mode is Optional: mode bits used to set permissions on this file.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          If not specified, the volume defaultMode will be used.
+                                          This might be in conflict with other options that affect the file
+                                          mode, like fsGroup, and the result can be other mode bits set.
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: |-
+                                          path is the relative path of the file to map the key to.
+                                          May not be an absolute path.
+                                          May not contain the path element '..'.
+                                          May not start with the string '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                optional:
+                                  description: optional field specify whether the
+                                    Secret or its keys must be defined
+                                  type: boolean
+                                secretName:
+                                  description: |-
+                                    secretName is the name of the secret in the pod's namespace to use.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                                  type: string
+                              type: object
+                            storageos:
+                              description: storageOS represents a StorageOS volume
+                                attached and mounted on Kubernetes nodes.
+                              properties:
+                                fsType:
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
+                                  type: boolean
+                                secretRef:
+                                  description: |-
+                                    secretRef specifies the secret to use for obtaining the StorageOS API
+                                    credentials.  If not specified, default values will be attempted.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                volumeName:
+                                  description: |-
+                                    volumeName is the human-readable name of the StorageOS volume.  Volume
+                                    names are only unique within a namespace.
+                                  type: string
+                                volumeNamespace:
+                                  description: |-
+                                    volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                                    namespace is specified then the Pod's namespace will be used.  This allows the
+                                    Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                                    Set VolumeName to any name to override the default behaviour.
+                                    Set to "default" if you are not using namespaces within StorageOS.
+                                    Namespaces that do not pre-exist within StorageOS will be created.
+                                  type: string
+                              type: object
+                            vsphereVolume:
+                              description: vsphereVolume represents a vSphere volume
+                                attached and mounted on kubelets host machine
+                              properties:
+                                fsType:
+                                  description: |-
+                                    fsType is filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  type: string
+                                storagePolicyID:
+                                  description: storagePolicyID is the storage Policy
+                                    Based Management (SPBM) profile ID associated
+                                    with the StoragePolicyName.
+                                  type: string
+                                storagePolicyName:
+                                  description: storagePolicyName is the storage Policy
+                                    Based Management (SPBM) profile name.
+                                  type: string
+                                volumePath:
+                                  description: volumePath is the path that identifies
+                                    vSphere volume vmdk
+                                  type: string
+                              required:
+                              - volumePath
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                  storage:
+                    description: Storage defines the persistent storage configuration
+                    properties:
+                      mountPath:
+                        description: MountPath is the path where the storage will
+                          be mounted in the container
+                        type: string
+                      size:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Size is the size of the persistent volume claim
+                          created for holding persistent data of the llama-stack server
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  userConfig:
+                    description: UserConfig defines the user configuration for the
+                      llama-stack server
+                    properties:
+                      configMapName:
+                        description: ConfigMapName is the name of the ConfigMap containing
+                          user configuration
+                        type: string
+                      configMapNamespace:
+                        description: ConfigMapNamespace is the namespace of the ConfigMap
+                          (defaults to the same namespace as the CR)
+                        type: string
+                    required:
+                    - configMapName
+                    type: object
+                required:
+                - distribution
+                type: object
+            required:
+            - server
+            type: object
+          status:
+            description: LlamaStackDistributionStatus defines the observed state of
+              LlamaStackDistribution.
+            properties:
+              availableReplicas:
+                description: AvailableReplicas is the number of available replicas
+                format: int32
+                type: integer
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the distribution's current state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              distributionConfig:
+                description: DistributionConfig contains the configuration information
+                  from the providers endpoint
+                properties:
+                  activeDistribution:
+                    description: ActiveDistribution shows which distribution is currently
+                      being used
+                    type: string
+                  availableDistributions:
+                    additionalProperties:
+                      type: string
+                    description: AvailableDistributions lists all available distributions
+                      and their images
+                    type: object
+                  providers:
+                    items:
+                      description: ProviderInfo represents a single provider from
+                        the providers endpoint.
+                      properties:
+                        api:
+                          type: string
+                        config:
+                          x-kubernetes-preserve-unknown-fields: true
+                        health:
+                          description: HealthStatus represents the health status of
+                            a provider
+                          properties:
+                            message:
+                              type: string
+                            status:
+                              type: string
+                          required:
+                          - message
+                          - status
+                          type: object
+                        provider_id:
+                          type: string
+                        provider_type:
+                          type: string
+                      required:
+                      - api
+                      - config
+                      - health
+                      - provider_id
+                      - provider_type
+                      type: object
+                    type: array
+                type: object
+              phase:
+                description: Phase represents the current phase of the distribution
+                enum:
+                - Pending
+                - Initializing
+                - Ready
+                - Failed
+                - Terminating
+                type: string
+              version:
+                description: Version contains version information for both operator
+                  and deployment
+                properties:
+                  lastUpdated:
+                    description: LastUpdated represents when the version information
+                      was last updated
+                    format: date-time
+                    type: string
+                  llamaStackServerVersion:
+                    description: DeploymentVersion is the version of the LlamaStack
+                      deployment
+                    type: string
+                  operatorVersion:
+                    description: OperatorVersion is the version of the operator managing
+                      this distribution
+                    type: string
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    selectableFields:
+    - jsonPath: .spec.server.userConfig.configMapName
+    - jsonPath: .spec.server.userConfig.configMapNamespace
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: llama-stack-k8s-operator
+    control-plane: controller-manager
+  name: llama-stack-k8s-operator-controller-manager
+  namespace: llama-stack-k8s-operator-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: llama-stack-k8s-operator
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        app.kubernetes.io/name: llama-stack-k8s-operator
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --leader-elect
+        command:
+        - /manager
+        env:
+        - name: OPERATOR_VERSION
+          value: latest
+        - name: LLAMA_STACK_VERSION
+          value: latest
+        image: quay.io/llamastack/llama-stack-k8s-operator:latest
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: llama-stack-k8s-operator-controller-manager
+      terminationGracePeriodSeconds: 10
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/name: llama-stack-k8s-operator
+    control-plane: controller-manager
+  name: llama-stack-k8s-operator-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: llama-stack-k8s-operator
+  name: llama-stack-k8s-operator-leader-election-role
+  namespace: llama-stack-k8s-operator-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: llama-stack-k8s-operator
+  name: llama-stack-k8s-operator-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - llamastack.io
+  resources:
+  - llamastackdistributions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - llamastack.io
+  resources:
+  - llamastackdistributions/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - llamastack.io
+  resources:
+  - llamastackdistributions/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: llama-stack-k8s-operator
+  name: llama-stack-k8s-operator-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: llama-stack-k8s-operator
+  name: llama-stack-k8s-operator-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: llama-stack-k8s-operator
+  name: llama-stack-k8s-operator-leader-election-rolebinding
+  namespace: llama-stack-k8s-operator-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: llama-stack-k8s-operator-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: llama-stack-k8s-operator-controller-manager
+  namespace: llama-stack-k8s-operator-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: llama-stack-k8s-operator
+  name: llama-stack-k8s-operator-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: llama-stack-k8s-operator-manager-role
+subjects:
+- kind: ServiceAccount
+  name: llama-stack-k8s-operator-controller-manager
+  namespace: llama-stack-k8s-operator-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: llama-stack-k8s-operator
+  name: llama-stack-k8s-operator-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: llama-stack-k8s-operator-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: llama-stack-k8s-operator-controller-manager
+  namespace: llama-stack-k8s-operator-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: llama-stack-k8s-operator
+    control-plane: controller-manager
+  name: llama-stack-k8s-operator-controller-manager-metrics-service
+  namespace: llama-stack-k8s-operator-system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    app.kubernetes.io/name: llama-stack-k8s-operator
+    control-plane: controller-manager
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: llama-stack-k8s-operator
+  name: llama-stack-k8s-operator-controller-manager
+  namespace: llama-stack-k8s-operator-system


### PR DESCRIPTION
Because RHOAI in 2.22 not includes the llama-stack-operator that supports custom run.yaml / userConfig, an lls-operator upstream can be used.

For that this PR enables the LLS Operator within the deploy-lab step, and then the llamastackdistribution CR can be used alongside the configmap (located in helmcharts)