### PR TITLE
Update memory limit for data-science-collector

### DIFF
--- a/toolings/templates/rhoai-monitoring/fix-monitoring-configmap-issue.yaml
+++ b/toolings/templates/rhoai-monitoring/fix-monitoring-configmap-issue.yaml
@@ -66,3 +66,6 @@ spec:
 
               # 3. Mount CA bundle in Prometheus
               oc patch prometheuses.monitoring.rhobs data-science-monitoringstack -n redhat-ods-monitoring --type=merge -p '{"spec":{"configMaps":["serving-certs-ca-bundle"]}}'
+
+              # 4. Fix-monitoring: Add more memory to the data-science-collector:
+              oc patch opentelemetrycollectors.opentelemetry.io data-science-collector --type='json' -p='[{"op": "replace", "path": "/spec/resources/limits/memory", "value":"1Gi"}]'

--- a/toolings/templates/rhoai-monitoring/fix-monitoring-configmap-issue.yaml
+++ b/toolings/templates/rhoai-monitoring/fix-monitoring-configmap-issue.yaml
@@ -18,6 +18,9 @@ rules:
 - apiGroups: ["monitoring.rhobs"]
   resources: ["prometheuses"]
   verbs: ["get", "patch", "update"]
+- apiGroups: ["opentelemetry.io"]
+  resources: ["opentelemetrycollectors"]
+  verbs: ["get", "patch", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
Increased memory limit for the data-science-collector to 1Gi. 

Prevents OOMKilling of the collector pods.

<img width="1458" height="430" alt="image" src="https://github.com/user-attachments/assets/201c2ce7-993d-41ab-9ad9-ef167882221b" />
